### PR TITLE
Support for old engine Auth.bin files

### DIFF
--- a/Common/includes/include.h
+++ b/Common/includes/include.h
@@ -1,0 +1,478 @@
+
+#ifndef TYPES_H
+#define TYPES_H
+
+typedef char bool;
+typedef char s8;
+typedef uchar u8;
+typedef int16 s16;
+typedef uint16 u16;
+typedef int16 s16;
+typedef int32 s32;
+typedef uint32 u32;
+typedef int64 s64;
+typedef uint64 u64;
+typedef hfloat f16;
+typedef float f32;
+typedef double f64;
+
+typedef struct
+{
+    f32 X;
+    f32 Y;
+} TVector2 <read=TVector2ToString>;
+
+string TVector2ToString( TVector2& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f]", value.X, value.Y );
+
+    return buffer;
+}
+
+typedef struct
+{
+    f16 X;
+    f16 Y;
+} TVector2Half <read=TVector2HalfToString>;
+
+string TVector2HalfToString( TVector2Half& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f]", value.X, value.Y );
+
+    return buffer;
+}
+
+typedef struct
+{
+    f32 X;
+    f32 Y;
+    f32 Z;
+} TVector3 <read=TVector3ToString>;
+
+string TVector3ToString( TVector3& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f]", value.X, value.Y, value.Z );
+
+    return buffer;
+}
+
+typedef struct
+{
+    f16 X;
+    f16 Y;
+	f16 Z;
+} TVector3Half <read=TVector3HalfToString>;
+
+string TVector3HalfToString( TVector3Half& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f]", value.X, value.Y, value.Z );
+
+    return buffer;
+}
+
+typedef struct
+{
+    f32 X;
+    f32 Y;
+    f32 Z;
+	f32 W;
+} TVector4 <read=TVector4ToString>;
+
+string TVector4ToString( TVector4& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f, %.6f]", value.X, value.Y, value.Z, value.W );
+
+    return buffer;
+}
+
+typedef TVector4 TQuaternion;
+
+typedef struct
+{
+    f16 X;
+    f16 Y;
+    f16 Z;
+	f16 W;
+} TVector4Half <read=TVector4HalfToString>;
+
+string TVector4HalfToString( TVector4Half& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f, %.6f]", value.X, value.Y, value.Z, value.W );
+
+    return buffer;
+}
+
+typedef TVector4Half TQuaternionHalf;
+
+typedef struct
+{
+	TVector3 Min;
+	TVector3 Max;
+} TExtents3D <read=TExtents3DToString>;
+
+string TExtents3DToString( TExtents3D& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f] [%.6f, %.6f, %.6f]", value.Min.X, value.Min.Y, value.Min.Z, value.Max.X, value.Max.Y, value.Max.Z );
+
+    return buffer;
+}
+
+typedef struct
+{
+	TVector3 Center;
+	f32 Radius;
+} TSphere3D <read=TSphere3DToString>;
+
+string TSphere3DToString( TSphere3D& value )
+{
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f] %.6f]", value.Center.X, value.Center.Y, value.Center.Z, value.Radius );
+
+    return buffer;
+}
+
+typedef struct
+{
+	u32 Value;
+} TNormal11_11_11 <read=TNormal11_11_10ToString>;
+
+string TNormal11_11_10ToString( TNormal11_11_11& value )
+{
+	const int FULL_WIDTH = 32;
+	
+	const int X_POS = 0;
+	const int X_WIDTH = 11;
+	const int X_LSHIFT = FULL_WIDTH - X_POS - X_WIDTH;
+	const int X_RSHIFT = FULL_WIDTH - X_WIDTH;
+	const int X_DOT = (1 << (X_WIDTH - 1)) - 1;
+	
+	const int Y_POS = X_POS + X_WIDTH;
+	const int Y_WIDTH = 11;
+	const int Y_LSHIFT = FULL_WIDTH - Y_POS - Y_WIDTH;
+	const int Y_RSHIFT = FULL_WIDTH - Y_WIDTH;
+	const int Y_DOT = (1 << (Y_WIDTH - 1)) - 1;
+	
+	const int Z_POS = Y_POS + Y_WIDTH;
+	const int Z_WIDTH = 10;	
+	const int Z_LSHIFT = FULL_WIDTH - Z_POS - Z_WIDTH;
+	const int Z_RSHIFT = FULL_WIDTH - Z_WIDTH;
+	const int Z_DOT = (1 << (Z_WIDTH - 1)) - 1;
+	
+	u32 packed = value.Value;
+
+	int xInt = ((int)(packed << X_LSHIFT)) >> X_RSHIFT;
+	int yInt = ((int)(packed << Y_LSHIFT)) >> Y_RSHIFT;
+	int zInt = ((int)(packed << Z_LSHIFT)) >> Z_RSHIFT;
+
+	f32 x = (float)xInt / (float)X_DOT;
+	f32 y = (float)yInt / (float)Y_DOT;
+	f32 z = (float)zInt / (float)Z_DOT;
+	
+    local char buffer[255];
+    SPrintf( buffer, "[%.6f, %.6f, %.6f]", x, y, z );
+
+	return buffer;
+}
+
+typedef struct( u32 base )
+{
+	u32 Offset;
+	
+	if ( Offset != 0 )
+	{
+		local u32 returnPos = FTell();
+		FSeek( base + Offset );
+		string Value;
+		FSeek( returnPos );
+	}
+} TStringOffset <read=TStringOffsetToString>;
+
+string TStringOffsetToString( TStringOffset& value )
+{
+	if ( value.Offset == 0 ) return "";
+    return value.Value;
+}
+
+typedef struct
+{
+    struct
+    {
+        f32 Column[4];
+    } Row[3];
+} TMatrix4x3;
+
+typedef struct
+{
+    struct
+    {
+        f32 Column[4];
+    } Row[4];
+} TMatrix4x4;
+
+#endif // #ifndef TYPES_H
+
+#ifndef UTILS_H
+#define UTILS_H
+
+void PrintValueUInt( string name, u64 value )
+{
+    PrintValueUIntEx( name, value, true );
+}
+
+void PrintValueUIntEx( string name, u64 value, bool newline )
+{
+    Printf( "%s: %8d (%08X) ", name, value, value );
+    if ( newline )
+        PrintNl();
+}
+
+void PrintValueFloat( string name, u64 value )
+{
+    PrintValueFloatEx( name, value, true );
+}
+
+void PrintValueFloatEx( string name, f32 value, bool newline )
+{
+    Printf( "%s: %8f ", name, value );
+    if ( newline )
+        PrintNl();
+}
+
+void PrintValueString( string name, string value )
+{
+    PrintValueStringEx( name, value, true );
+}
+
+void PrintValueStringEx( string name, string value, bool newline )
+{
+    Printf( "%s: %s ", name, value );
+    if ( newline )
+        PrintNl();
+}
+
+void PrintNl()
+{
+    Printf( "\n" );
+}
+
+void PrintArrayUInt( string name, u32 array[], u32 count )
+{
+    local s32 i;
+    local string elementName = "";
+    for ( i = 0; i < count; ++i )
+    {     
+        SPrintf( elementName, "%s[%d]", name, i );
+        PrintValueUInt( elementName, array[i] ); 
+    }
+}
+
+//---------------------------------------------
+// Random color
+//---------------------------------------------
+local u32 __RandomSeed = 0xDEADBABE;
+local u32 __RandomBit = 0;
+local u32 __RandomCount = 0;
+ 
+u32 MyRandom( u32 to )
+{
+    ++__RandomCount;
+    __RandomBit  = ( (__RandomSeed >> 0 ) ^ ( __RandomSeed >> 2 ) ^ ( __RandomSeed >> 3 ) ^ ( __RandomSeed >> 5 ) ) & 1;
+    __RandomSeed = ( ( ( ( __RandomBit << 15 ) | ( __RandomSeed >> 1 ) ) + ( 0xBABE / __RandomCount ) ) % to );
+
+    while( __RandomSeed < 0 )
+        __RandomSeed += to;
+
+    return __RandomSeed;
+}
+
+local u32 __LastRandomColor = 0;
+u32 RandomColor()
+{
+    return __LastRandomColor = MyRandom( 0xFFFFFFFF );
+}
+
+u32 SetRandomBackColor()
+{
+    local u32 color = RandomColor();
+    SetBackColor( color );
+    return color;
+}
+
+u32 GetShadeOfLastColor(s32 amount)
+{    
+    local u32 r = (__LastRandomColor & 0x000000FFu) + amount; 
+    if (r > 0xFF) r = 0xFF;
+
+    local u32 g = ((__LastRandomColor & 0x0000FF00u) >> 8u) + amount; 
+    if (g > 0xFF) g = 0xFF;
+
+    local u32 b = ((__LastRandomColor & 0x00FF0000u) >> 16u) + amount; 
+    if (b > 0xFF) b = 0xFF;
+
+    __LastRandomColor = r | g << 8u | b << 16u;  
+    return __LastRandomColor;
+}
+
+u32 GetLighterShadeOfLastColor()
+{
+    return GetShadeOfLastColor( 0x10 );
+}
+
+u32 SetBackColorToShadeOfLastColor(s32 amount)
+{
+    local u32 color = GetShadeOfLastColor(amount);
+    SetBackColor( color );
+    return color;
+}
+
+u32 SetBackColorToLighterShadeOfLastColor()
+{
+    local u32 color = GetShadeOfLastColor(0x10);
+    SetBackColor( color );
+    return color;
+}
+
+// Generate u32 from FourCC in string format
+u32 ReadFourCC()
+{
+    local bool isLittle = IsLittleEndian();
+
+    if (isLittle)
+        BigEndian();
+
+    local u32 value = ReadUInt();
+
+    if (isLittle)
+        LittleEndian();
+
+    return value;
+}
+
+u32 FourCC( string str )
+{
+    return (u32)str[0] << 24 | (u32)str[1] << 16 | (u32)str[2] << 8 | (u32)str[3];
+}
+
+u32 MakeFourCC( string str )
+{
+    if ( IsLittleEndian() )
+        return (u32)str[0] | (u32)str[1] << 8 | (u32)str[2] << 16 | (u32)str[3] << 24;
+    else
+        return (u32)str[3] | (u32)str[2] << 8 | (u32)str[1] << 16 | (u32)str[0] << 24;
+}
+
+u32 Align( u32 value, u32 alignment )
+{
+	return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+void FAlign( u32 alignment )
+{
+	FSeek( Align( FTell(), alignment ) );
+}
+
+local u64 gBasePositionStack[32];
+local u32 gBasePositionStackIndex = 0;
+local u64 gBasePosition = 0;
+
+local u64 gPositionStack[32];
+local u32 gPositionStackIndex = 0;
+
+void FPushBase()
+{
+    gBasePosition = gBasePositionStack[ ++gBasePositionStackIndex ] = FTell();
+    //PrintValueUInt( "Push: gBasePosition", gBasePosition ); 
+}
+
+void FPopBase()
+{
+    gBasePosition = gBasePositionStack[ --gBasePositionStackIndex ];
+    //PrintValueUInt( "Pop: gBasePosition", gBasePosition ); 
+}
+
+void FPush()
+{
+    gPositionStack[ ++gPositionStackIndex ] = FTell();
+}
+
+void FPushRel( u64 pos )
+{
+    gPositionStack[ ++gPositionStackIndex ] = FTell();
+    FSeekRel( pos );
+}
+
+void FPushAbs( u64 pos )
+{
+    gPositionStack[ ++gPositionStackIndex ] = FTell();
+    FSeek( pos );
+}
+
+void FPop()
+{
+    FSeek( gPositionStack[ gPositionStackIndex-- ] );
+}
+
+void FSeekRel( u64 pos )
+{
+    FSeek( gBasePosition + pos );
+}
+
+s32 ArrayIndexOfUInt( u32 array[], u32 count, u32 value )
+{
+    local s32 i;
+    for ( i = 0; i < count; ++i )
+        if ( array[i] == value )
+            return i;
+
+    return -1;
+}
+
+bool ArrayContainsUInt( u32 array[], u32 count, u32 value )
+{
+    return ArrayIndexOfUInt( array, count, value ) != -1;
+}
+
+void ArrayFillUInt( u32 array[], u32 count, u32 value )
+{
+    local u32 i;
+    for ( i = 0; i < count; ++i )
+        array[i] = value;
+}
+
+void ArrayMinUInt( u32 array[], u32 count )
+{
+    local u32 i;
+    local u32 min = 0xFFFFFFFF;
+
+    for ( i = 0; i < count; ++i )
+    {
+        if ( array[i] < min ) 
+            min = array[i];
+    }
+
+    return max;
+}
+
+void ArrayMaxUInt( u32 array[], u32 count )
+{
+    local u32 i;
+    local u32 max = 0;
+
+    for ( i = 0; i < count; ++i )
+    {
+        if ( array[i] > max ) 
+            max = array[i];
+    }
+
+    return max;
+}
+
+
+#endif // #ifndef UTILS_H

--- a/Old Engine/auth/yakuza_auth.bt
+++ b/Old Engine/auth/yakuza_auth.bt
@@ -1,7 +1,7 @@
 //------------------------------------------------
 //--- 010 Editor v10.0.2 Binary Template
 //
-//      File: yakuza_gmt.bt 
+//      File: yakuza_auth.bt 
 //   Authors: SutandoTsukai181 (Based on TGE's templates) 
 //   Version: 1.0 
 //   Purpose: Parse Yakuza series Auth.bin files

--- a/Old Engine/auth/yakuza_auth.bt
+++ b/Old Engine/auth/yakuza_auth.bt
@@ -1,0 +1,183 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: yakuza_gmt.bt 
+//   Authors: SutandoTsukai181 (Based on TGE's templates) 
+//   Version: 1.0 
+//   Purpose: Parse Yakuza series Auth.bin files
+//  Category:  
+// File Mask: Auth.bin 
+//  ID Bytes:  
+//   History:  
+//------------------------------------------------ 
+
+#include "../../Common/includes/include.h"
+
+typedef struct
+{
+    SetRandomBackColor();
+    LittleEndian();
+    char Magic[4];      // AUTH
+    u8 Endianness0;     // 2 for big, 21 for little
+    u8 Endianness1;     // 1 for big, 0 for little
+    if ( Endianness1 == 1 ) BigEndian();
+    FSkip( 0x2 );
+    u32 Version;
+    FSkip( 0x4 );
+
+    u32 FileSize;
+    u32 Sec2Start;
+    u32 Sec2Count;
+    u32 EntriesStart;
+
+    u32 Sec4Start;
+    u32 Sec4Count;
+    f32 TotalFrames;    // Not completely sure
+    u32 EntriesCount;
+
+    u32 Sec3Start;
+    FSkip( 0xC );
+
+    local u32 entryColor = SetRandomBackColor();
+    local u32 dataColor = SetRandomBackColor();
+    local u32 dataHeaderColor = SetRandomBackColor();
+    local u32 sec2Color = SetRandomBackColor();
+    local u32 sec3Color = SetRandomBackColor();
+    local u32 sec4Color = SetRandomBackColor();
+    local u32 sec5Color = SetRandomBackColor();
+
+	if ( EntriesStart && EntriesCount )
+	{
+		//FSeekRel( EntriesStart );
+		SetBackColor( entryColor );
+        //struct { struct TEntry Entry[ EntriesCount ]; } Entries;
+        struct { ReadEntries( 0, EntriesStart, 0 ); } Entries;
+	}
+
+    if ( Sec2Start && Sec2Count )
+    {
+        FSeekRel( Sec2Start );
+        SetBackColor( sec2Color );
+        struct { struct TFramePair FramePair[ Sec2Count ]; } FramePairs1;
+    }
+
+    if ( Sec3Start && EntriesCount )
+    {
+        FSeekRel( Sec3Start );
+        SetBackColor( sec3Color );
+        struct { struct TFramePair FramePair[ EntriesCount ]; } FramePairs2;
+    }
+
+    if ( Sec4Start && Sec4Count )
+    {
+        FSeekRel( Sec4Start );
+        SetBackColor( sec4Color );
+        struct { struct TSec4Entry Sec4Entry[ Sec4Count ]; } Section4;
+    }
+
+} TAuth;
+
+typedef struct
+{
+    u32 Field00;
+    u32 Field04;
+
+    u8 Reference[ 0x10 ];   // Used as a reference for other parts of the file or for resources
+
+    u32 Field18[ 3 ];       // All 0
+	u32 Field24;            // 0 or 1
+
+	u32 Field28[ 4 ];       // All 0
+    f32 Field38[ 3 ];       // All 1
+    u32 Field44;            // 1
+
+    u32 Field48[ 6 ];       // All 0
+
+    u32 Sec5Offset;
+    u32 Field64;            // 0
+    u32 DataOffset;
+    u32 ChildEntryOffset;   // Offset to child entry
+
+    u32 NextEntryOffset;    // Offset to next entry
+    u32 Field74[ 3 ];       // All 0
+
+    FPush();
+	{
+		FSeekRel( Sec5Offset );
+
+        SetBackColor( sec5Color );
+		struct TSec5Entry Sec5Entry;
+        SetBackColor( entryColor );
+	}
+	FPop();
+
+	FPush();
+	{
+		FSeekRel( DataOffset );
+        SetBackColor( dataColor );
+
+        // There might be more than 1 structure for each entry but the actual count is unknown
+		struct TEntryData EntryData;
+        SetBackColor( entryColor );
+	}
+	FPop();
+
+} TEntry <optimize=false>;
+
+typedef struct
+{
+    f32 StartFrame;   // Not confirmed
+    f32 EndFrame;
+    f32 Field08[ 2 ]; // All 0
+} TFramePair;
+
+typedef struct
+{
+    u32 Field00;
+	u8 Reference[ 0x10 ];
+	u32 Field14[ 3 ];
+} TSec4Entry;
+
+typedef struct
+{
+    u32 Field00;
+    u32 Field04;
+	u8 Reference[ 0x10 ];
+	f32 StartFrame;       // Not confirmed
+    f32 EndFrame;
+    u32 Field20[ 24 ];    // All 0
+} TSec5Entry;
+
+typedef struct
+{
+    SetBackColor( dataHeaderColor );
+	u8 Reference[ 0x10 ];
+	u32 TypeFlag;         // Not confirmed
+    u32 DataSize;
+    u32 Field18[ 2 ];     // All 0
+
+    SetBackColor( dataColor );
+    u8 Data[ DataSize ];
+} TEntryData <optimize=false>;
+
+void ReadEntries( u32 child, u32 next, u32 currentCount )
+{
+    local u32 entryStart = child;
+    if ( child == 0 )
+    {
+        entryStart = next;
+        next = 0;
+    }
+
+    FSeekRel( entryStart );
+    struct TEntry Entry;
+
+    child = Auth.Entries.Entry[currentCount].ChildEntryOffset;
+    if ( Auth.Entries.Entry[currentCount].NextEntryOffset != 0 )
+        next = Auth.Entries.Entry[currentCount].NextEntryOffset;
+
+    if ( child != 0 || next != 0 )
+        ReadEntries( child, next, currentCount + 1 );
+}
+
+TAuth Auth;


### PR DESCRIPTION
Only works with Auth.bin, as Resource.bin has a different structure.

include.h file was taken from [TGEnigma's templates repository](https://github.com/TGEnigma/010-Editor-Templates).

To use the new include.h header, add `#include "Common/includes/include.h"` at the top of the template after changing the relative path. For example, since yakuza_auth.bt is in `Old Engine/auth/`, the correct relative path would be going up 2 folders, or `#include "../../Common/includes/include.h"`