### PR TITLE
Add PS2 Yakuza DAT and texture templates

### DIFF
--- a/Common/includes/include.h
+++ b/Common/includes/include.h
@@ -1,6 +1,6 @@
 
-#ifndef TYPES_H
-#define TYPES_H
+#ifndef COMMON
+#define COMMON
 
 typedef char bool;
 typedef char s8;
@@ -215,11 +215,6 @@ typedef struct
         f32 Column[4];
     } Row[4];
 } TMatrix4x4;
-
-#endif // #ifndef TYPES_H
-
-#ifndef UTILS_H
-#define UTILS_H
 
 void PrintValueUInt( string name, u64 value )
 {
@@ -474,5 +469,4 @@ void ArrayMaxUInt( u32 array[], u32 count )
     return max;
 }
 
-
-#endif // #ifndef UTILS_H
+#endif // #ifndef COMMON

--- a/PS2 Engine/yakuza2_dat.bt
+++ b/PS2 Engine/yakuza2_dat.bt
@@ -1,0 +1,97 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: yakuza2_dat.bt 
+//   Authors: SutandoTsukai181
+//   Version: 1.0 
+//   Purpose: Parse Yakuza 1 and 2 .dat files
+//  Category: 
+// File Mask: *.dat
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------ 
+
+#define DAT
+
+#include "../Common/includes/include.h"
+#include "yakuza2_txb.bt"
+
+typedef struct
+{
+    SetRandomBackColor();
+    LittleEndian();
+
+    u32 OmeStart <format=hex>;
+    u32 OmeCount;
+    u32 TxbStart <format=hex>;
+    u32 TxbCount;
+
+    u32 Sec3Start <format=hex>;
+    u32 Sec3Count;
+    u32 Field18;
+    u32 Field1C;
+
+    local u32 headerColor = SetRandomBackColor();
+    local u32 omeColor = SetRandomBackColor();
+    local u32 txbColor = SetRandomBackColor();
+    local u32 sec3Color = SetRandomBackColor();
+
+    if ( OmeStart && OmeCount )
+    {
+        FSeekRel( OmeStart );
+        struct { struct TOmeEntry Ome[ OmeCount ]; } OMEs;
+    }
+
+    if ( TxbStart && TxbCount )
+    {
+        FSeekRel( TxbStart );
+        struct { struct TTxbEntry Txb[ TxbCount ]; } TXBs;
+    }
+
+    if ( Sec3Start && Sec3Count )
+    {
+        FSeekRel( Sec3Start );
+        struct { struct TSec3Entry Sec3[ Sec3Count ]; } Sec3;
+    }
+
+} TDat;
+
+typedef struct
+{
+    SetBackColor( headerColor );
+    u32 Size <format=hex>;
+    u32 Unk[ 3 ];
+
+    #ifdef OME
+        TOme Ome;
+    #else
+        SetBackColor( omeColor );
+        u8 Data[ Size ];
+    #endif
+} TOmeEntry <optimize=false>;
+
+typedef struct
+{
+    SetBackColor( headerColor );
+    u32 Size <format=hex>;
+    u32 Unk[ 3 ];
+
+    #ifdef TXB
+        TTxb Txb;
+    #else
+        SetBackColor( txbColor );
+        u8 Data[ Size ];
+    #endif
+} TTxbEntry <optimize=false>;
+
+typedef struct
+{
+    SetBackColor( headerColor );
+    u32 Size <format=hex>;
+    u32 Unk[ 3 ];
+
+    SetBackColor( sec3Color );
+    u8 Data[ Size ];
+} TSec3Entry <optimize=false>;
+
+TDat Dat;

--- a/PS2 Engine/yakuza2_sgt.bt
+++ b/PS2 Engine/yakuza2_sgt.bt
@@ -1,0 +1,41 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: yakuza2_sgt.bt 
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Parse Yakuza 1 and 2 .sgt files
+//  Category: 
+// File Mask: *.sgt
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------ 
+
+#define SGT
+
+#include "../Common/includes/include.h"
+#include "yakuza2_txb.bt"
+
+typedef struct
+{
+    SetRandomBackColor();
+    LittleEndian();
+
+    char Magic[4]; // SGT
+    u32 ResX;
+    u32 ResY;
+    u32 TextureStart <format=hex>;
+
+    u32 TextureStart1 <format=hex>; // Same as TextureStart
+    u32 Width;
+    u32 Height;
+    u32 TextureCount;
+
+    #ifdef TXB
+        TTxb Txb;
+    #endif
+} TSgt;
+
+#ifndef DAT   // Just in case we find a DAT that contains an SGT
+    TSgt Sgt;
+#endif

--- a/PS2 Engine/yakuza2_txb.bt
+++ b/PS2 Engine/yakuza2_txb.bt
@@ -1,0 +1,71 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: yakuza2_txb.bt 
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Parse Yakuza 1 and 2 .txb files
+//  Category: 
+// File Mask: *.txb
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------ 
+
+#ifndef TXB
+#define TXB
+
+#include "../Common/includes/include.h"
+
+typedef struct
+{
+    SetRandomBackColor();
+    LittleEndian();
+
+    char Magic[4];      // TXBP
+    u32 TextureCount;   // Number of layers/textures
+    u32 DataSize;       // Size without header
+    FSkip( 0x14 );
+
+    local u32 headerColor = SetRandomBackColor();
+    local u32 textureColor = SetRandomBackColor();
+
+    struct
+    { 
+        local u32 currentTex = 0;
+        while ( currentTex < TextureCount )
+        {
+            struct TTexture Texture;
+            currentTex++;
+        }
+    } Textures;
+
+} TTxb;
+
+typedef struct
+{
+    SetBackColor( headerColor );
+
+    u32 Size <format=hex>;
+
+    #ifdef SGT
+        u32 ResX;
+        u32 ResY;
+    #else
+        u32 Res;
+        u32 Field08;
+    #endif
+
+    u32 Mipmaps;      // Not sure
+    s32 Unk[ 4 ];
+
+    SetBackColor( textureColor );
+    u8 TextureData[ Size ];
+} TTexture <optimize=false>;
+
+#ifndef DAT
+    #ifndef SGT
+        TTxb Txb;
+    #endif
+#endif
+
+#endif // #ifndef TXB

--- a/PS2 Engine/yakuza2_txb.bt
+++ b/PS2 Engine/yakuza2_txb.bt
@@ -62,10 +62,10 @@ typedef struct
     u8 TextureData[ Size ];
 } TTexture <optimize=false>;
 
+#endif // #ifndef TXB
+
 #ifndef DAT
     #ifndef SGT
         TTxb Txb;
     #endif
 #endif
-
-#endif // #ifndef TXB


### PR DESCRIPTION
DAT files contain models and textures for cutscenes.
TXBP is the texture format, which can contain multiple textures.
SGT contains one TXBP, but is used to combine the layers/textures into 1 big texture.

yakuza2_dat.bt and yakuza2_sgt.bt can apply the TXBP template on textures inside them.