### PR TITLE
Add Kurohyo 1 and 2 templates

### DIFF
--- a/PSP Engine/base.bt
+++ b/PSP Engine/base.bt
@@ -1,0 +1,48 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: base.bt
+//   Authors: SutandoTsukai181, initial template by Violet
+//   Version: 1.0
+//   Purpose: Contains structs for "base" bone transforms format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_BASE
+#define KUROHYO_BASE
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "base", "Unexpected magic.");
+    struct TKString Name;
+
+    u16 Count;
+    struct TBaseBone Bone[Count] <optimize=false>;
+} TBase;
+
+typedef struct
+{
+    u16 FormatFlags;
+    struct TKString Name;
+
+    struct TVector3 Scale;
+    struct TVector3 Rotation;
+    struct TVector3 Location;
+} TBaseBone <read=ReadTBaseBone>;
+
+string ReadTBaseBone(TBaseBone& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TBase base;
+#endif
+
+#endif  // KUROHYO_BASE

--- a/PSP Engine/came.bt
+++ b/PSP Engine/came.bt
@@ -1,0 +1,54 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: came.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "came" camera settings format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_CAME
+#define KUROHYO_CAME
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "came", "Unexpected magic.");
+
+    u16 Count;
+    struct TCameNode Node[Count] <optimize=false>;
+} TCame;
+
+typedef struct
+{
+    u16 FormatFlags;
+    struct TKString Name;
+
+    u32 CameraFlags;
+
+    TVector3 InitialLocation;
+    TVector3 InitialFocusPoint;
+
+    f32 InitialRollDegrees;
+    f32 InitialFovDegrees;
+
+    f32 ClipStart;
+    f32 ClipEnd;
+} TCameNode <read=ReadTCameNode>;
+
+string ReadTCameNode(TCameNode& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TCame came;
+#endif
+
+#endif  // KUROHYO_CAME

--- a/PSP Engine/common.h
+++ b/PSP Engine/common.h
@@ -1,0 +1,36 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: common.h
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Common include for Kurohyo templates
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_COMMON
+#define KUROHYO_COMMON
+
+#include "../Common/includes/include.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "end ", "Unexpected magic.");
+} TEnd;
+
+typedef struct
+{
+    u16 Length;
+    char Data[Length];
+} TKString <read=ReadTKString>;
+
+string ReadTKString(TKString& value)
+{
+    return (value.Length == 0) ? "" : value.Data;
+}
+
+#endif

--- a/PSP Engine/elpk.bt
+++ b/PSP Engine/elpk.bt
@@ -1,0 +1,56 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: elpk.bt
+//   Authors: SutandoTsukai181, based on Capitan Retraso's rELPKckr
+//   Version: 1.0
+//   Purpose: Parses Kurohyo ELPK containers
+//  Category: 
+// File Mask: *
+//  ID Bytes: 45 4C 50 4B
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_ELPK
+#define KUROHYO_ELPK
+
+#include "common.h"
+#include "kurohyo.bt"
+
+local u32 elpkColor = SetRandomBackColor();
+
+typedef struct
+{
+    LittleEndian();
+    SetBackColor(elpkColor);
+
+    char Magic[4];
+    Assert(Magic == "ELPK", "Unexpected magic.");
+
+    u32 FileSize;
+    u32 Flags;
+    u32 Padding;
+
+    u32 PageCount;
+    struct TElpkPage Page[PageCount] <optimize=false>;
+} TElpk;
+
+typedef struct
+{
+    u32 PageHash <format=hex>;
+    u32 PageOffset;
+    u32 PageSize;
+
+    FPush();
+    {
+        FSeekRel(PageOffset);
+        if (ReadKurohyoFiles())
+            struct TElpk ELPK;
+    }
+    FPop();
+} TElpkPage;
+
+Assert(ReadUShort() != 0x8B1F, "File has Gzip compression. Cannot parse ELPK unless it is decompressed.");
+struct TElpk ELPK;
+
+#endif  // KUROHYO_ELPK

--- a/PSP Engine/imag.bt
+++ b/PSP Engine/imag.bt
@@ -1,0 +1,44 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: imag.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "imag" image reference format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_IMAG
+#define KUROHYO_IMAG
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "imag", "Unexpected magic.");
+
+    u16 Count;
+    struct TImagItem Texture[Count] <optimize=false>;
+} TImag;
+
+typedef struct
+{
+    u16 Flags;
+    u32 Hash <format=hex>;
+    struct TKString Name;
+} TImagItem <read=ReadTImagItem>;
+
+string ReadTImagItem(TImagItem& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TImag imag;
+#endif
+
+#endif  // KUROHYO_IMAG

--- a/PSP Engine/kurohyo.bt
+++ b/PSP Engine/kurohyo.bt
@@ -1,0 +1,98 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: kurohyo.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Parses unpacked Kurohyo files
+//  Category: 
+// File Mask: *.imag,*.pose,*.skel
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_MAIN
+#define KUROHYO_MAIN
+
+#include "common.h"
+
+#include "base.bt"
+#include "came.bt"
+#include "imag.bt"
+#include "ligh.bt"
+#include "mate.bt"
+#include "mode.bt"
+#include "pose.bt"
+#include "skel.bt"
+
+local u32 baseColor = SetRandomBackColor();
+local u32 cameColor = SetRandomBackColor();
+local u32 endColor  = SetRandomBackColor();
+local u32 imagColor = SetRandomBackColor();
+local u32 lighColor = SetRandomBackColor();
+local u32 mateColor = SetRandomBackColor();
+local u32 modeColor = SetRandomBackColor();
+local u32 poseColor = SetRandomBackColor();
+local u32 skelColor = SetRandomBackColor();
+
+bool ReadKurohyoFiles()
+{
+    LittleEndian();
+    local char magic[4];
+    do
+    {
+        magic = ReadString(FTell(), 4);
+        switch (magic)
+        {
+            case "base":
+                SetBackColor(baseColor);
+                struct TBase Base;
+                break;
+            case "came":
+                SetBackColor(cameColor);
+                struct TCame Came;
+                break;
+            case "ELPK":
+                return true;
+            case "end ":
+                SetBackColor(endColor);
+                struct TEnd End;
+                break;
+            case "imag":
+                SetBackColor(imagColor);
+                struct TImag Imag;
+                break;
+            case "ligh":
+                SetBackColor(lighColor);
+                struct TLigh Ligh;
+                break;
+            case "mate":
+                SetBackColor(mateColor);
+                struct TMate Mate;
+                break;
+            case "mode":
+                SetBackColor(modeColor);
+                struct TMode Mode;
+                break;
+            case "pose":
+                SetBackColor(poseColor);
+                struct TPose Pose;
+                break;
+            case "skel":
+                SetBackColor(skelColor);
+                struct TSkel Skel;
+                break;
+            default:
+                return false;
+        }
+    }
+    while (magic != "end ");
+
+    return false;
+}
+
+#ifndef KUROHYO_ELPK
+ReadKurohyoFiles();
+#endif
+
+#endif  // KUROHYO_MAIN

--- a/PSP Engine/ligh.bt
+++ b/PSP Engine/ligh.bt
@@ -1,0 +1,49 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: ligh.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "ligh" light objects format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_LIGH
+#define KUROHYO_LIGH
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "ligh", "Unexpected magic.");
+
+    u16 Count;
+    struct TLighItem Lights[Count] <optimize=false>;
+} TLigh;
+
+typedef struct
+{
+    u16 Flags;
+    struct TKString Name;
+
+    u32 UnkCount;
+
+    TVector3 Location;
+    u8  UnkBytes[13];
+    f32 UnkFloats[5];
+} TLighItem <read=ReadTLighItem>;
+
+string ReadTLighItem(TLighItem& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TLigh ligh;
+#endif
+
+#endif  // KUROHYO_LIGH

--- a/PSP Engine/mate.bt
+++ b/PSP Engine/mate.bt
@@ -1,0 +1,59 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: mate.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "mate" material format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_MATE
+#define KUROHYO_MATE
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert( Magic == "mate" );
+
+    u16 Count;
+    struct TMateItem Material[Count] <optimize=false>;
+} TMate;
+
+typedef struct
+{
+    u16 Flags;
+    struct TKString Name;
+    u32 ShaderHash <format=hex>;    // I have no idea if this is true
+    f32 UnkFloat[2];
+
+    struct TMateGroup Group[5] <optimize=false>;
+} TMateItem <read=ReadTMateItem>;
+
+string ReadTMateItem(TMateItem& value)
+{
+    return ReadTKString(value.Name);
+}
+
+typedef struct
+{
+    u16 TextureCount;
+    struct TMateTexture Texture[TextureCount] <optimize=false>;
+} TMateGroup;
+
+typedef struct
+{
+    u16 Flags;  // 0x405 means an actual texture from an imag
+    u32 TextureHash <format=hex>;
+} TMateTexture;
+
+#ifndef KUROHYO_MAIN
+struct TMate mate;
+#endif
+
+#endif  // KUROHYO_MATE

--- a/PSP Engine/mode.bt
+++ b/PSP Engine/mode.bt
@@ -1,0 +1,223 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: mode.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "mode" model format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_MODE
+#define KUROHYO_MODE
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "mode", "Unexpected magic.");
+
+    struct TModeNode RootNode;
+} TMode;
+
+typedef struct
+{
+    u16 Flags;
+    struct TKString Name;
+
+    // 0x40 is dual face (render backface)
+    // 0x0B is transparency (alpha blend)
+    u32 ModelFlags;
+
+    if ((Flags & 0x04) == 0x04)
+    {
+        // Clones an existing node into the given coordinates
+        TVector3 InstanceScale;
+        TVector3 InstanceRotation;
+        TVector3 InstanceLocation;
+        struct TKString ClonedNodeName;
+    }
+    else if ((Flags & 0x0F) > 2)
+    {
+        f32 Unk0;
+        u8  Unk1;   //Assert(Unk1 == 2);
+
+        TVector3 BoundingBoxPoint[2];
+
+        local bool isUnskinned = (Flags & 0x03) == 0x03;
+        if ((Flags & 0x08) == 0x08 && !isUnskinned)
+        {
+            u16 MeshCount;
+            struct TModeMesh Mesh(isUnskinned)[MeshCount] <optimize=false>;
+        }
+        else
+        {
+            struct TModeMesh Mesh(isUnskinned);
+        }
+
+        struct TKString MaterialName;
+    }
+
+    u16 ChildCount;
+    struct TModeNode Child[ChildCount] <optimize=false>;
+} TModeNode <read=ReadTModeNode>;
+
+typedef struct(bool isUnskinned)
+{
+    if (!isUnskinned)
+    {
+        u16 BoneCount;
+
+        // Hash performed on the bone name is FNV-0 with the prime 0x811C9DC5
+        u32 BoneHashes[BoneCount] <format=hex>;
+    }
+
+    u16 TriangleCount;
+    struct TModeTri Triangles[TriangleCount];
+
+    u32 VertexFlags <format=hex>;
+    u16 VertexCount;
+
+    struct
+    {
+        local int i;
+        for (i = 0; i < VertexCount; i++)
+        {
+            struct TModeVertex Vertex(VertexFlags);
+        }
+    } Vertices;
+
+    u16 HasStrips;
+    Assert((HasStrips == 0) || (HasStrips == 1));
+
+    if (HasStrips)
+        struct TModeStrips Strips;
+} TModeMesh;
+
+typedef struct
+{
+    u16 Indices[3];
+} TModeTri;
+
+typedef struct(u32 VertexFlags)
+{
+    // The vertex flags are not only used as "bools" for checking whether
+    // some values exist or not, because some flags completely change the functionality
+    // of other flags if they're enabled. Some flags are missing from here, as I only
+    // added support for character, weapon, and stage models, and they didn't use
+    // flags other than the ones in here.
+
+    local int weightsCount = 1;
+
+    if ((VertexFlags & 0x10000) == 0x10000)
+    {
+        weightsCount += 4;
+    }
+
+    if ((VertexFlags & 0x8000) == 0x8000)
+    {
+        weightsCount += 2;
+    }
+
+    if ((VertexFlags & 0x4000) == 0x4000)
+    {
+        ++weightsCount;
+    }
+
+    if ((VertexFlags & 0x0400) == 0x0400)
+    {
+        f32 BoneWeights[weightsCount];
+    }
+
+    if ((VertexFlags & 0x0200) == 0x0200)
+    {
+        s16 UVs[2] <read=ReadShortScaled>;
+    }
+
+    if ((VertexFlags & 0x0003) == 0x0003)
+    {
+        f32 UnkFloats[2];
+    }
+
+    if ((VertexFlags & 0x0018) == 0x0018)
+    {
+        struct TModeVertexColor VertexColor((VertexFlags & 0x000F) != 0x000F);
+    }
+
+    if ((VertexFlags & 0x0040) == 0x0040)
+    {
+         s16 Normals[3] <read=ReadShortScaled>;
+
+        if ((VertexFlags & 0x0018) == 0)
+        {
+            u16 Padding;
+        }
+    }
+
+    if ((VertexFlags & 0x0180) == 0x0180)
+    {
+         TVector3 Location;
+    }
+} TModeVertex;
+
+string ReadShortScaled(s16& value)
+{
+    local string str = "";
+    SPrintf( str, "%.6f", (f32)value / 0x7FFF );
+    return str;
+}
+
+typedef struct(bool is16bit)
+{
+    local bool isShort = is16bit;
+
+    if (isShort)
+    {
+        u16 R : 4;
+        u16 G : 4;
+        u16 B : 4;
+        u16 A : 4;
+    }
+    else
+    {
+        u8 R;
+        u8 G;
+        u8 B;
+        u8 A;
+    }
+} TModeVertexColor <read=ReadTModeVertexColor>;
+
+string ReadTModeVertexColor(TModeVertexColor& value)
+{
+    local u8 scale = value.isShort ? 0xF : 0xFF;
+    local string str = "";
+
+    SPrintf( str, "RGBA: [%f, %f, %f, %f]",
+        (f32)value.R / scale,
+        (f32)value.G / scale,
+        (f32)value.B / scale,
+        (f32)value.A / scale );
+
+    return str;
+}
+
+typedef struct
+{
+    u16 Count;
+    u16 Indices[Count];
+} TModeStrips;
+
+string ReadTModeNode(TModeNode& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TMode mode;
+#endif
+
+#endif  // KUROHYO_MODE

--- a/PSP Engine/pose.bt
+++ b/PSP Engine/pose.bt
@@ -1,0 +1,164 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: pose.bt
+//   Authors: SutandoTsukai181
+//   Version: 1.0
+//   Purpose: Contains structs for "pose" animation format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_POSE
+#define KUROHYO_POSE
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "pose", "Unexpected magic.");
+
+    struct TKString Name;
+
+    // 0x8001 - skeleton short
+    // 0x0002 - skeleton float
+    // 0x03 - camera
+    // 0x05 - weird 1.0 for all channels, used for billboards?
+    u16 FormatFlags;
+
+    u16 Count;
+    u32 DataSize;
+    f32 EndFrame;
+
+    struct TNode Node[Count] <optimize=false>;
+} TPose;
+
+typedef struct
+{
+    s16 X;
+    s16 Y;
+    s16 Z;
+} TKHVector3Short <read=ReadTKHVector3Short>;
+
+string ReadTKHVector3Short(TKHVector3Short& value)
+{
+    local string str = "";
+    SPrintf(str, "[%.6f, %.6f, %.6f]", (f32)value.X / 0x03FF, (f32)value.Y / 0x03FF, (f32)value.Z / 0x03FF);
+    return str;
+}
+
+typedef struct
+{
+    u16 FormatFlags;
+    struct TKString Name;
+
+    if ((parentof(this).FormatFlags & 0x8000) == 0x8000)
+    {
+        struct TKHVector3Short InitialScale;
+        struct TKHVector3Short InitialRotation;
+        struct TKHVector3Short InitialLocation;
+    }
+    else
+    {
+        TVector3 InitialScale;
+        TVector3 InitialRotation;
+        TVector3 InitialLocation;
+    }
+
+    u32 UnkFlags;
+    u16 ChannelFlags;
+
+    if ((parentof(this).FormatFlags & 0x03) == 0x03)
+    {
+        // Camera
+        if (ChannelFlags & 0x0100)
+            struct TChannel CameraRollRadian;
+        if (ChannelFlags & 0x80)
+            struct TChannel CameraFovDegrees;
+        if (ChannelFlags & 0x40)
+            struct TChannel CameraUnk;  // Might be unused
+
+        // Focus point
+        if (ChannelFlags & 0x20)
+            struct TChannel FocusX;
+        if (ChannelFlags & 0x10)
+            struct TChannel FocusY;
+        if (ChannelFlags & 0x08)
+            struct TChannel FocusZ;
+    }
+    else
+    {
+        // Skeletons
+        if (ChannelFlags & 0x0100)
+            struct TChannel ScaleX;
+        if (ChannelFlags & 0x80)
+            struct TChannel ScaleY;
+        if (ChannelFlags & 0x40)
+            struct TChannel ScaleZ;
+
+        // Rotation is radian euler angles
+        if (ChannelFlags & 0x20)
+            struct TChannel RotationX;
+        if (ChannelFlags & 0x10)
+            struct TChannel RotationY;
+        if (ChannelFlags & 0x08)
+            struct TChannel RotationZ;
+    }
+
+    if (ChannelFlags & 0x04)
+        struct TChannel LocationX;
+    if (ChannelFlags & 0x02)
+        struct TChannel LocationY;
+    if (ChannelFlags & 0x01)
+        struct TChannel LocationZ;
+} TNode <read=ReadTNode>;
+
+string ReadTNode(TNode& value)
+{
+    return ReadTKString(value.Name);
+}
+
+typedef struct
+{
+    u32 Count;
+
+    if (parentof(parentof(this)).FormatFlags & 0x8000)
+        struct TShortKeyframe Frame[Count] <optimize=false>;
+    else
+        struct TFloatKeyframe Frame[Count] <optimize=false>;
+} TChannel;
+
+typedef struct
+{
+    s16 Value;
+    u16 Frame;
+} TShortKeyframe <read=ReadTShortKeyframe>;
+
+string ReadTShortKeyframe(TShortKeyframe& value)
+{
+    local string str = "";
+    SPrintf(str, "[frame: %d, value: %.6f]", value.Frame, (f32)value.Value / 0x03FF);
+    return str;
+}
+
+typedef struct
+{
+    f32 Value;
+    f32 Frame;
+} TFloatKeyframe <read=ReadTFloatKeyframe>;
+
+string ReadTFloatKeyframe(TFloatKeyframe& value)
+{
+    local string str = "";
+    SPrintf(str, "[frame: %.1f, value: %.6f]", value.Frame, value.Value);
+    return str;
+}
+
+#ifndef KUROHYO_MAIN
+struct TPose pose;
+#endif
+
+#endif  // KUROHYO_POSE

--- a/PSP Engine/skel.bt
+++ b/PSP Engine/skel.bt
@@ -1,0 +1,47 @@
+//------------------------------------------------
+//--- 010 Editor v10.0.2 Binary Template
+//
+//      File: skel.bt
+//   Authors: SutandoTsukai181, initial template by Violet
+//   Version: 1.0
+//   Purpose: Contains structs for "skel" skeleton hierarchy format for Kurohyo games
+//  Category: 
+// File Mask: 
+//  ID Bytes: 
+//   History: 
+//------------------------------------------------
+
+#ifndef KUROHYO_SKEL
+#define KUROHYO_SKEL
+
+#include "common.h"
+
+typedef struct
+{
+    char Magic[4];
+    Assert(Magic == "skel", "Unexpected magic.");
+
+    struct TSkelNode RootNode;
+} TSkel;
+
+typedef struct
+{
+    u16 FormatFlags;
+    struct TKString Name;
+
+    u32 SkelFlags;
+
+    u16 ChildCount;
+    struct TSkelNode Child[ChildCount] <optimize=false>;
+} TSkelNode <read=ReadTSkelNode>;
+
+string ReadTSkelNode(TSkelNode& value)
+{
+    return ReadTKString(value.Name);
+}
+
+#ifndef KUROHYO_MAIN
+struct TSkel skel;
+#endif
+
+#endif  // KUROHYO_SKEL


### PR DESCRIPTION
## Installing
Add elpk.bt and kurohyo.bt to the installed templates. The other files need to be in the same directory, but only those 2 files should be installed.

## Usage
`elpk.bt` will automatically run for files that have the ELPK magic. If the template is ran manually and the file is compressed (with gzip), a message will be shown to indicate so.

`kurohyo.bt` will automatically run for supported files that have been unpacked with [rELPKckr](https://github.com/CapitanRetraso/rELPKckr). Those files need to have an extension of either `.imag`, `.pose`, or `.skel`.

If a file doesn't get detected automatically, you can run the template manually.
Supported formats (magics):

- **base**: Skeleton base transforms
- **came**: Camera settings
- **ELPK**: ELPK container
- **imag**: Image references (for materials)
- **ligh**: Light objects
- **mate**: Materials (for models)
- **mode**: Models
- **pose**: Animations (for skeletons and cameras)
- **skel**: Skeleton hierarchy